### PR TITLE
Use stable gandi API url

### DIFF
--- a/set-gandi-dns-record.sh
+++ b/set-gandi-dns-record.sh
@@ -2,5 +2,5 @@
 
 # requires: HTTPie
 
-http put "https://dns.beta.gandi.net/api/v5/zones/$GANDI_ZONE_UUID/records/@/A" X-Api-key:"$GANDI_API_KEY" rrset_ttl:=900 rrset_values:='["'$(./get-external-ip-via-stun.sh)'"]'
+http put "https://dns.api.gandi.net/api/v5/zones/$GANDI_ZONE_UUID/records/@/A" X-Api-key:"$GANDI_API_KEY" rrset_ttl:=900 rrset_values:='["'$(./get-external-ip-via-stun.sh)'"]'
 


### PR DESCRIPTION
The gandi api has changed its url for a more stable
one. Although https://dns.beta.gandi.net will continue to 
work for the foreseable future, this commits updates the
url to new official one.